### PR TITLE
Changing the emote id from Int to String

### DIFF
--- a/src/commonMain/kotlin/com/ktmi/tmi/messages/Utility.kt
+++ b/src/commonMain/kotlin/com/ktmi/tmi/messages/Utility.kt
@@ -57,7 +57,7 @@ fun String.parseTwitchPairSet() = this
  * in the [TextMessage.message]
  */
 data class Emote(
-    val id: Int,
+    val id: String,
     val positions: List<Pair<Int, Int>>
 )
 
@@ -70,7 +70,7 @@ fun String.parseTwitchEmotes() = this
     .map { it.split(":") }
     .filter { it.size == 2 }
     .map { emote -> Emote(
-        emote[0].toInt(),
+        emote[0],
         emote[1].split(",")
             .map { it.split("-") }
             .map { it[0].toInt() to it[1].toInt() }


### PR DESCRIPTION
The data type of the emote id isn't very obvious until you start using the Channel Points feature "Modify a Single Emote" in a streamer's channel.

For example here is the id of an unmodified emote: `2002555`
While here is the id of the same emote with the sunglasses modifier: `2002555_SG`